### PR TITLE
#9 Move versioning to separate resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,10 +12,6 @@ resource "aws_s3_bucket" "this" {
   acl    = var.acl
   tags   = var.tags
 
-  versioning {
-    enabled = var.versioning_enabled
-  }
-
   force_destroy = var.force_destroy
 
   server_side_encryption_configuration {
@@ -41,4 +37,25 @@ resource "aws_s3_bucket_public_access_block" "this" {
   block_public_policy     = var.block_public_policy
   ignore_public_acls      = var.ignore_public_acls
   restrict_public_buckets = var.restrict_public_buckets
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Create a versioning configuration resource on S3 Bucket.
+#
+# For MFA delete details, see:
+# https://docs.aws.amazon.com/AmazonS3/latest/userguide/MultiFactorAuthenticationDelete.html
+#
+# Provider Doc: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning
+# ---------------------------------------------------------------------------------------------------------------------
+resource "aws_s3_bucket_versioning" "this" {
+  count = var.versioning_enabled ? 1 : 0
+
+  bucket                = aws_s3_bucket.this.id
+  expected_bucket_owner = var.versioning_expected_bucket_owner
+  mfa                   = var.versioning_mfa
+
+  versioning_configuration {
+    status     = "Enabled"
+    mfa_delete = var.versioning_mfa_delete
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -48,6 +48,24 @@ variable "versioning_enabled" {
   default     = true
 }
 
+variable "versioning_mfa_delete" {
+  description = "Whether to require MFA when permanently deleting an object or changing versioning state"
+  type        = string
+  default     = "Disabled"
+}
+
+variable "versioning_mfa" {
+  description = "MFA device if MFA delete is enabled"
+  type        = string
+  default     = null
+}
+
+variable "versioning_expected_bucket_owner" {
+  description = "Account ID of the expected bucket owner"
+  type        = string
+  default     = null
+}
+
 variable "acl" {
   description = "Access policy options for the s3 bucket"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -83,3 +83,9 @@ variable "kms_key_id" {
   type        = string
   default     = null
 }
+
+variable "bucket_key_enabled" {
+  description = "Whether to use short-lived bucket keys to save on KMS costs"
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -67,9 +67,15 @@ variable "versioning_expected_bucket_owner" {
 }
 
 variable "acl" {
-  description = "Access policy options for the s3 bucket"
+  description = "Canned access control policy options for the s3 bucket"
   type        = string
   default     = "private"
+}
+
+variable "object_ownership" {
+  description = "Object ownership"
+  type        = string
+  default     = "BucketOwnerPreferred"
 }
 
 variable "tags" {


### PR DESCRIPTION
Inline versioning configuration is deprecated in newer versions of the
AWS provider. This change moves the versioning configuration into a
separate resource.
